### PR TITLE
Update main.tf with updated vmss requirement

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,7 @@ resource "azurerm_virtual_machine_scale_set" "vm-linux" {
     ip_configuration {
       name                                   = "IPConfiguration"
       subnet_id                              = "${var.vnet_subnet_id}"
+      primary                                = true
       load_balancer_backend_address_pool_ids = ["${var.load_balancer_backend_address_pool_ids}"]
     }
   }


### PR DESCRIPTION
This is the same issue referenced in the pull [request](https://github.com/Azure/terraform-azurerm-computegroup/pull/20)

The ip_configuration now requires a primary setting.