### PR TITLE
[26432] Enable late handling of cloud-init template rendering

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,7 @@ resource "azurerm_virtual_machine_scale_set" "vm-linux" {
     ip_configuration {
       name                                   = "IPConfiguration"
       subnet_id                              = "${var.vnet_subnet_id}"
+      primary                                = true
       load_balancer_backend_address_pool_ids = ["${var.load_balancer_backend_address_pool_ids}"]
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,8 @@ resource "azurerm_resource_group" "vmss" {
 }
 
 data "template_file" "cloudconfig" {
-  template = "${file("${var.cloudconfig_file}")}"
+  template = "${file(var.cloudconfig_template_file)}"
+  vars     = "${var.cloudconfig_template_vars}"
 }
 
 data "template_cloudinit_config" "config" {

--- a/variables.tf
+++ b/variables.tf
@@ -105,6 +105,11 @@ variable "tags" {
   }
 }
 
-variable "cloudconfig_file" {
+variable "cloudconfig_template_file" {
   description = "The location of the cloud init configuration file."
+}
+
+variable "cloudconfig_template_vars" {
+  type        = "map"
+  description = "A map of vars to use in the cloud config template file"
 }


### PR DESCRIPTION
This PR is an extension to another PR that has been open since Nov 2018 on the upstream repo: https://github.com/Azure/terraform-azurerm-vmss-cloudinit/pull/5
(that PR is necessary if using the latest azurerm terraform provider, which we are)

This one enables late rendering of cloud-init template with vars (passed into the module as a map on key/value pairs) that get values late in the deployment process.
